### PR TITLE
Potential fix for code scanning alert no. 11: Disabled Spring CSRF protection

### DIFF
--- a/src/main/java/com/inn/cafe/JWT/SecurityConfig.java
+++ b/src/main/java/com/inn/cafe/JWT/SecurityConfig.java
@@ -58,7 +58,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         corsConfiguration.setAllowedOrigins(List.of(frontEndUrl));
         http.cors().configurationSource(request -> new CorsConfiguration(corsConfiguration).applyPermitDefaultValues())
                 .and()
-                .csrf().disable()
+                .csrf()
+                    .ignoringAntMatchers("/user/login", "/user/signUp", "/user/forgotPassword", "/swagger-ui/*", "/v3/api-docs/**")
+                .and()
                 .authorizeRequests()
                 .antMatchers("/user/login", "/user/signUp", "/user/forgotPassword","/swagger-ui/*","/v3/api-docs/**")
                 .permitAll()


### PR DESCRIPTION
Potential fix for [https://github.com/fabrice78912/com.inn.cafe/security/code-scanning/11](https://github.com/fabrice78912/com.inn.cafe/security/code-scanning/11)

In general, the fix is to stop globally disabling CSRF protection and instead either (1) enable CSRF with appropriate token handling (e.g., using cookies + header‑echo for SPA) and explicitly ignore only those endpoints that truly cannot be exploited via CSRF, or (2) justify and constrain the configuration so that credentials are never automatically sent by the browser (not reliably checkable from this snippet alone). Since we can only change this file, the safest concrete fix is to remove the blanket `csrf().disable()` call and replace it with a more restrictive setup that still allows the current public endpoints to function.

The single best change that preserves behavior while restoring protection is to:
- Replace `.csrf().disable()` with a CSRF configuration that:
  - Enables CSRF by default.
  - Optionally ignores CSRF for the login/signup/password‑reset and Swagger endpoints, which are currently `permitAll` and may be called without CSRF tokens.
- Keep the rest of the HTTP security configuration (CORS, authorization rules, stateless sessions, JWT filter) unchanged.

Concretely, in `src/main/java/com/inn/cafe/JWT/SecurityConfig.java`:
- Modify the `configure(HttpSecurity http)` method to remove `.csrf().disable()` and instead call `.csrf().ignoringAntMatchers(...)` (or `ignoringRequestMatchers` in newer APIs, but we must stay consistent with the existing Spring Security style here which uses `antMatchers`).
- No new imports are required because `ignoringAntMatchers` is part of the `CsrfConfigurer` DSL returned by `csrf()`; we’re not introducing new types.

This results in CSRF being active for all other endpoints (including authenticated, state‑changing ones), while the explicitly ignored paths can still be called without providing a CSRF token, which matches the original behavior as closely as possible within this file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
